### PR TITLE
escape quotation marks to make qrcode work on android

### DIFF
--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -96,7 +96,7 @@ var QRCode = createReactClass({
                 <Canvas
                     context={{
                         size: size,
-                        value: this.props.value,
+                        value: this.props.value.replace(/%22/g, '%5C%22'),
                         bgColor: this.props.bgColor,
                         fgColor: this.props.fgColor,
                         cells: qr(value).modules,


### PR DESCRIPTION
Signed-off-by: Josip@Sylo <josip@sylo.io>

| WIP  | Type  |
| :---: | :---: |
| No | Fix |

## Description

_We changed the way we encode data which is being converted to a qrcode. Now we rely on using quotation marks and they conflict with the way WebView's source is being handled. Seems like it's using eval on the string that is passed so we need to escape or remove quotation marks._
